### PR TITLE
Minor improvements for S32N platform

### DIFF
--- a/server/src/platform/s32n.cc
+++ b/server/src/platform/s32n.cc
@@ -138,14 +138,16 @@ class Platform_s32n final : public Platform_arm, public Boot_modules_image_mode
 
   void init() override
   {
-    // Setup core TCMs
-    static unsigned long const tcm_bases[4] =
-    {
-      Rtu_tcm_c0_base, Rtu_tcm_c1_base, Rtu_tcm_c2_base, Rtu_tcm_c3_base
-    };
-    unsigned long tcm_base = tcm_bases[current_node()];
+    // Enable TCMs at EL2 and EL1/0
+    unsigned long tcm_base = 0;
+    switch (current_node())
+      {
+      case 0: tcm_base = Rtu_tcm_c0_base; break;
+      case 2: tcm_base = Rtu_tcm_c2_base; break;
+      default: panic("Running on invalid core!\n"); break;
+      }
 
-    // IMP_xTCMREGIONR. ENABLEEL2=1, ENABLEEL10=1
+    // IMP_xTCMREGIONR
     asm volatile ("mcr p15, 0, %0, c9, c1, 0" : : "r"(tcm_base | 0x00000003));
     asm volatile ("mcr p15, 0, %0, c9, c1, 1" : : "r"(tcm_base | 0x00100003));
     asm volatile ("mcr p15, 0, %0, c9, c1, 2" : : "r"(tcm_base | 0x00200003));

--- a/server/src/platform/s32n.cc
+++ b/server/src/platform/s32n.cc
@@ -59,10 +59,15 @@ class Platform_s32n final : public Platform_arm, public Boot_modules_image_mode
    */
   static bool validate_area(Region *search_area, [[maybe_unused]] unsigned node)
   {
+    enum : unsigned long
+    {
 #ifdef CONFIG_BOOTSTRAP_PF_S32N_DYN_ALLOC_OVERRIDE
-    enum : unsigned long {
       Dyn_alloc_begin = CONFIG_BOOTSTRAP_PF_S32N_DYN_ALLOC_START,
       Dyn_alloc_end   = CONFIG_BOOTSTRAP_PF_S32N_DYN_ALLOC_END,
+#else
+      Dyn_alloc_begin = Rtu_cram_base,
+      Dyn_alloc_end   = Rtu_cram_end,
+#endif
     };
 
     if (search_area->begin() <= Dyn_alloc_end
@@ -74,17 +79,6 @@ class Platform_s32n final : public Platform_arm, public Boot_modules_image_mode
           search_area->end(Dyn_alloc_end);
         return true;
       }
-#else
-    if (search_area->begin() <= Rtu_cram_end
-        && search_area->end() >= Rtu_cram_base)
-      {
-        if (search_area->begin() < Rtu_cram_base)
-          search_area->begin(Rtu_cram_base);
-        if (search_area->end() > Rtu_cram_end)
-          search_area->end(Rtu_cram_end);
-        return true;
-      }
-#endif
 
     return false;
   }


### PR DESCRIPTION
- Merged default RTU CRAM handling into existing override logic using a single enum.
- Kept initialization of TCMs only for the cores running bootstrap.
    